### PR TITLE
Protect from failures in bucket creation.

### DIFF
--- a/src/uswitch/bifrost/s3.clj
+++ b/src/uswitch/bifrost/s3.clj
@@ -90,7 +90,11 @@
     (info "Starting S3Upload component.")
     (when-not (bucket-exists? credentials bucket)
       (info "Creating" bucket "bucket")
-      (create-bucket credentials bucket))
+      (try
+        (create-bucket credentials bucket)
+        (catch Throwable t
+          (warn "Creation of bucket" bucket "failed with error" (.getMessage t)
+                ". Assuming it will be there when we need it."))))
     (thread
      (loop []
        (let [msg (<!! rotated-event-ch)]


### PR DESCRIPTION
The scenario this mitigates is when we start a number of bifrost
instances simultaneously and they race to create the bucket. The losers
get an exception and then fail to start the upload thread, meaning they
never process anything.

We could implement a retry here, but it seems over complicated for this
use case. With this change the Worse case is that we get an exception
later that the bucket doesn't exist.
